### PR TITLE
Do not run the two failing Behat tests until we make them more stable

### DIFF
--- a/behatstability.sh
+++ b/behatstability.sh
@@ -6,4 +6,4 @@ PROJECT_FOLDER=/var/www/html/profiles/contrib/social/tests/behat
 
 echo $PROJECT_FOLDER/config/behat.yml;
 
-/var/www/vendor/bin/behat $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags "stability"
+/var/www/vendor/bin/behat $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags "stability&&~DS-2082&&~DS-816"


### PR DESCRIPTION
Disable the two Behat tests that fail often. They still should run in https://github.com/goalgorilla/open_social_testing/blob/master/scripts/ci/behatstability.sh