### PR TITLE
DS-3893 by bramtenhove: Add a check coding standards script

### DIFF
--- a/check-coding-standards.sh
+++ b/check-coding-standards.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+REPORT=--report=summary
+
+if [ ${1:-"summary"} = "full" ]; then
+  REPORT=--report-full
+fi
+
+# Set some configurations.
+# @todo add this to the Dockerfile at some point and remove the ignore flags.
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths /var/www/vendor/drupal/coder/coder_sniffer
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set ignore_errors_on_exit 1
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set ignore_warnings_on_exit 1
+
+# Run PHP Code Sniffer.
+echo "Running PHP Code Sniffer."
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=Drupal --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social


### PR DESCRIPTION
## Prerequisite
Make sure either https://github.com/goalgorilla/drupal_social/pull/318 is merged or you are on that branch in the `drupal_social` repo.

## Readme
This script runs the Code Sniffer with a Drupal configuration in `profiles/contrib/social`. By default it will display a summary of the errors and warnings it found, but you can also get a more detailed report.

**Summary report**
`docker exec -i social_web bash /var/www/scripts/social/check-coding-standards.sh`

**Detailed report**
Simply add `full`.
`docker exec -i social_web bash /var/www/scripts/social/check-coding-standards.sh full`

## Possible improvements
At this moment I added some configuration options in the script. However we should add the `installed_paths` option in the Dockerfile at some point.

Also I made sure it does not give an `exit 1` on any findings for now. When we fixed the majority or all of the issues we should remove the options and make it fail the build if any issues were found.

## How to test
- [x] Run the command for the **summary** report, you should see a list of files with the amount of errors and warnings founds
- [x] Run the command for the **detailed** report, you should see the findings per file