### PR TITLE
DS-3830 by frankgraave, bramtenhove: Add ability to run multiple tags…

### DIFF
--- a/behatstability.sh
+++ b/behatstability.sh
@@ -1,9 +1,33 @@
 #!/usr/bin/env bash
 
+# Take optional arguments for this script.
+#
+# To run all stability tests except for DS-2082 and DS-816:
+# /behatstability.sh
+# To run specified tags except for DS-2082 and DS-816:
+# /behatstability.sh stability-1 stability-2 stability-5
+if [ -z "$1" ];
+then
+  TAGS="stability&&~DS-2082&&~DS-816"
+else
+  for var in "$@"
+  do
+    if [ -z "$TAGS" ];
+    then
+      TAGS="$var"
+    else
+      TAGS="$TAGS,$var"
+    fi
+  done
+  TAGS="$TAGS&&~DS-2082&&~DS-816"
+fi
+
+echo $TAGS;
+
 PROJECT_FOLDER=/var/www/html/profiles/contrib/social/tests/behat
 
 /var/www/vendor/bin/behat --version
 
 echo $PROJECT_FOLDER/config/behat.yml;
 
-/var/www/vendor/bin/behat $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags "stability&&~DS-2082&&~DS-816"
+/var/www/vendor/bin/behat $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags $TAGS

--- a/behatstability.sh
+++ b/behatstability.sh
@@ -22,12 +22,8 @@ else
   TAGS="$TAGS&&~DS-2082&&~DS-816"
 fi
 
-echo $TAGS;
-
 PROJECT_FOLDER=/var/www/html/profiles/contrib/social/tests/behat
 
 /var/www/vendor/bin/behat --version
-
-echo $PROJECT_FOLDER/config/behat.yml;
 
 /var/www/vendor/bin/behat $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags $TAGS


### PR DESCRIPTION
## Description
Run with default tags: `docker exec -i social_behat bash /var/www/scripts/social/behatstability.sh`
Run with custom tags: `docker exec -i social_behat bash /var/www/scripts/social/behatstability.sh account login`

## How to test
- [x] Run the behatstability script with no tags, should use default tags: stability&&~DS-2082&&~DS-816
- [x] Run the behatstability script with one tag, should run test with specified tag and still exclude ~DS-2082&&~DS-816
- [x] Run the behatstability script with multiple tags, should run test with specified tag and still exclude ~DS-2082&&~DS-816