### PR TITLE
Enable the create-open-group feature behat

### DIFF
--- a/behatstability.sh
+++ b/behatstability.sh
@@ -2,13 +2,13 @@
 
 # Take optional arguments for this script.
 #
-# To run all stability tests except for DS-2082 and DS-816:
+# To run all stability tests except for DS-2082:
 # /behatstability.sh
-# To run specified tags except for DS-2082 and DS-816:
+# To run specified tags except for DS-2082:
 # /behatstability.sh stability-1 stability-2 stability-5
 if [ -z "$1" ];
 then
-  TAGS="stability&&~DS-2082&&~DS-816"
+  TAGS="stability&&~DS-2082"
 else
   for var in "$@"
   do
@@ -19,7 +19,7 @@ else
       TAGS="$TAGS,$var"
     fi
   done
-  TAGS="$TAGS&&~DS-2082&&~DS-816"
+  TAGS="$TAGS&&~DS-2082"
 fi
 
 PROJECT_FOLDER=/var/www/html/profiles/contrib/social/tests/behat


### PR DESCRIPTION
# Background info
After looking into a PR on the distro, I found out the create-open-group.feature was not enabled. Fixed the behat and now we should enable it once again.

# HTT
- [x] Check the changes
- [x] Make sure https://github.com/goalgorilla/open_social/pull/512 is merged.
- [x] Merge