### PR TITLE
2840680 by frankgraave: enable last behat that was excluded

### DIFF
--- a/behatstability.sh
+++ b/behatstability.sh
@@ -2,13 +2,13 @@
 
 # Take optional arguments for this script.
 #
-# To run all stability tests except for DS-2082:
+# To run all stability tests:
 # /behatstability.sh
-# To run specified tags except for DS-2082:
+# To run specified tags:
 # /behatstability.sh stability-1 stability-2 stability-5
 if [ -z "$1" ];
 then
-  TAGS="stability&&~DS-2082"
+  TAGS="stability"
 else
   for var in "$@"
   do
@@ -19,7 +19,7 @@ else
       TAGS="$TAGS,$var"
     fi
   done
-  TAGS="$TAGS&&~DS-2082"
+  TAGS="$TAGS"
 fi
 
 PROJECT_FOLDER=/var/www/html/profiles/contrib/social/tests/behat


### PR DESCRIPTION
# Background
There were two behats excluded since January 2017. One (`DS-811`) was already fixed, but now only the `DS-2082` remains. I ran the test locally and it seems to be running just fine. So we enable this test too see if it also turns green on Travis. Related issue: https://www.drupal.org/node/2840680

# HTT
- [x] Merge this PR
- [ ] Merge 8.x-1.x back into a PR on the open_social repo
- [ ] See if the `DS-2082` test fails or passes
- [ ] Upon the result keep this PR merged or revert this change