### PR TITLE
DS-4398 - Enable build failing for Drupal coding standards Sniffer

### DIFF
--- a/check-coding-standards.sh
+++ b/check-coding-standards.sh
@@ -14,12 +14,11 @@ fi
 
 # Run PHP Code Sniffer.
 echo "Running PHP Code Sniffer with Drupal sniffer."
-/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=Drupal --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml
-
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=Drupal --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml --ignore=.github/PULL_REQUEST_TEMPLATE.md
 
 # Ignore warnings on exit for DrupalPractice.
 /var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set ignore_warnings_on_exit 1
 
 # Run PHP Code Sniffer.
 echo "Running PHP Code Sniffer with DrupalPractice sniffer."
-/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml --ignore=.github/PULL_REQUEST_TEMPLATE.md

--- a/check-coding-standards.sh
+++ b/check-coding-standards.sh
@@ -9,9 +9,17 @@ fi
 # Set some configurations.
 # @todo add this to the Dockerfile at some point and remove the ignore flags.
 /var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths /var/www/vendor/drupal/coder/coder_sniffer
-/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set ignore_errors_on_exit 1
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set ignore_errors_on_exit 0
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set ignore_warnings_on_exit 0
+
+# Run PHP Code Sniffer.
+echo "Running PHP Code Sniffer with Drupal sniffer."
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=Drupal --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml
+
+
+# Ignore warnings on exit for DrupalPractice.
 /var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set ignore_warnings_on_exit 1
 
 # Run PHP Code Sniffer.
-echo "Running PHP Code Sniffer."
-/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=Drupal --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/*
+echo "Running PHP Code Sniffer with DrupalPractice sniffer."
+/var/www/vendor/squizlabs/php_codesniffer/scripts/phpcs $REPORT --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml


### PR DESCRIPTION
## Description

As part of cleaning up the last coding standard issue we should enable the check on the CI. If code with coding standards errors is pushed this will result in a build failure on the CI.

## Note

If you merge this before https://github.com/goalgorilla/open_social/pull/618 is merged it could mean all builds will fail ;)

Then again, you can put the ignore errors and warnings back quite easily.