### PR TITLE
Exit with non-zero exit status if install fails

### DIFF
--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Ensure we exit with an error on drush errors.
+set -e
 
 # Install script for in the docker container.
 cd /var/www/html/;


### PR DESCRIPTION
We're testing a Drupal website. So if we can't install Drupal there's no point of trying to continue the installation or any testing. We should just quit at this point and let a developer fix it.