### PR TITLE
DS-4757 - Skip updates when requiring updated OS version

### DIFF
--- a/ci/build-install-update.sh
+++ b/ci/build-install-update.sh
@@ -6,7 +6,7 @@ set -ev
 docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh
 bash scripts/social/ci/restore-permissions.sh
 # Update composer to version Y.
-rm -f composer.lock && composer require goalgorilla/open_social:dev-${2}#${3} --update-with-dependencies
+rm -f composer.lock && composer require goalgorilla/open_social:dev-${2}#${3} --no-update
 # do this anyway
 composer update
 bash scripts/social/ci/restore-permissions.sh


### PR DESCRIPTION
When updating from 1.0 to the latest version we run into dependency issues.

As we are doing a `composer update` anyway, we can also skip `--update-with-dependencies`. This solves the issue.