### PR TITLE
Issue #2949044 by Kingdutch: Use Drupal Core's phpunit.xml.dist file …

### DIFF
--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-php -d xdebug.extended_info=0 -d xdebug.remote_autostart=0 -d xdebug.coverage_enable=0 -d xdebug.profiler_enable=0 -d xdebug.remote_enable=0 /var/www/vendor/bin/phpunit -c /var/www/html/profiles/contrib/social/phpunit.xml.dist --testsuite social
+php -d xdebug.extended_info=0 -d xdebug.remote_autostart=0 -d xdebug.coverage_enable=0 -d xdebug.profiler_enable=0 -d xdebug.remote_enable=0 /var/www/vendor/bin/phpunit -c /var/www/html/core/phpunit.xml.dist --testsuite unit --group social


### PR DESCRIPTION
…instead of our own

This commit will cause no unit tests to be run until
feature/2949044-core-phpunit-xml 8658a8f is merged in the
goalgorilla/open_social repo. At that point it will continue to
run all Open Social unit tests as before.

See https://www.drupal.org/project/social/issues/2949044