### PR TITLE
Be more verbose when running Behat tests

### DIFF
--- a/behatstability.sh
+++ b/behatstability.sh
@@ -26,4 +26,4 @@ PROJECT_FOLDER=/var/www/html/profiles/contrib/social/tests/behat
 
 /var/www/vendor/bin/behat --version
 
-/var/www/vendor/bin/behat $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags $TAGS
+/var/www/vendor/bin/behat -vv $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags $TAGS


### PR DESCRIPTION
By adding `-vv` to the Behat bin file when executing it we'll receive stack traces when a PHP error occurs.

This is super helpful to understand what is going wrong, even more when it occurs in the queue where screenshots won't help.