### PR TITLE
by robertragas: also run activity_send_email_worker to relieve the be…

### DIFF
--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -121,6 +121,7 @@ else
   drush queue-run activity_logger_message
   drush queue-run activity_creator_logger
   drush queue-run activity_creator_activities
+  drush queue-run activity_send_email_worker
   fn_sleep
   echo "trigger a search api re-index"
   drush php-eval 'drush_search_api_reset_tracker();';


### PR DESCRIPTION
…hat tests of clearing this queue

**Problem**
After the demo content has been installed it will run all the queues but the "activity_send_email_worker". When the behat tests are starting it first needs to process this queue and could possibly cause a timeout.

**Solution**
Also run the activity_send_email_worker queue, this will be stopped by the email catcher anyway. We might also choose to truncate the table if we don't use these spool emails anyway.