### PR TITLE
Change script for running tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+php -d xdebug.extended_info=0 -d xdebug.remote_autostart=0 -d xdebug.coverage_enable=0 -d xdebug.profiler_enable=0 -d xdebug.remote_enable=0 /var/www/vendor/bin/phpunit -c /var/www/html/profiles/contrib/social/phpunit.xml.dist "$@"

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-php -d xdebug.extended_info=0 -d xdebug.remote_autostart=0 -d xdebug.coverage_enable=0 -d xdebug.profiler_enable=0 -d xdebug.remote_enable=0 /var/www/vendor/bin/phpunit -c /var/www/html/profiles/contrib/social/phpunit.xml.dist --testsuite social
+./run-tests.sh --testsuite social


### PR DESCRIPTION
A new script is created to run tests that does not specify the testsuite
from the Open Social phpunit configuration. The script also allows
passing extra flags to PHPUnit which makes it easy to select specific
classes or testsuites without having to figure out the specific command
for PHPUnit using Open Social's test configuration.

The existing unit-test.sh file is kept and targets specifically the
social test-suite so that Travis keeps working.