### PR TITLE
SnippetAcceptingContext is deprecated

### DIFF
--- a/behatstability.sh
+++ b/behatstability.sh
@@ -26,4 +26,5 @@ PROJECT_FOLDER=/var/www/html/profiles/contrib/social/tests/behat
 
 /var/www/vendor/bin/behat --version
 
-/var/www/vendor/bin/behat -vv $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags $TAGS
+# --snippets-for=cli is needed for output in newer versions of Behat.
+/var/www/vendor/bin/behat -vv $PROJECT_FOLDER --config $PROJECT_FOLDER/config/behat.yml --tags $TAGS --snippets-for=cli


### PR DESCRIPTION
https://github.com/goalgorilla/open_social/pull/1969
We will fix and report any deprecated code, since also behat is taken care of, we need to fix SnippetAcceptingContext as well.
In this case we can just remove it and ensure behat still outputs its cli values correctly. 