### PR TITLE
Issue #3188183 - Swiftmailer doesn't allow for PHP as transport option, so on our local machines us SMTP

### DIFF
--- a/check-coding-standards.sh
+++ b/check-coding-standards.sh
@@ -16,4 +16,4 @@ ${PHPCS} --config-set ignore_warnings_on_exit 0
 
 # Run PHP Code Sniffer.
 echo "Running PHP Code Sniffer with Drupal sniffer."
-${PHPCS} --report-full --standard=Drupal,DrupalPractice --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml --ignore=.github/PULL_REQUEST_TEMPLATE.md
+${PHPCS} $REPORT --standard=Drupal --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml --ignore=.github/PULL_REQUEST_TEMPLATE.md

--- a/check-coding-standards.sh
+++ b/check-coding-standards.sh
@@ -16,4 +16,4 @@ ${PHPCS} --config-set ignore_warnings_on_exit 0
 
 # Run PHP Code Sniffer.
 echo "Running PHP Code Sniffer with Drupal sniffer."
-${PHPCS} $REPORT --standard=Drupal --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml --ignore=.github/PULL_REQUEST_TEMPLATE.md
+${PHPCS} --report-full --standard=Drupal,DrupalPractice --extensions=php,module,inc,install,test,profile,theme /var/www/html/profiles/contrib/social --ignore=*/node_modules/* --ignore=*.css --ignore=social.info.yml --ignore=.github/PULL_REQUEST_TEMPLATE.md

--- a/install/default.settings.php
+++ b/install/default.settings.php
@@ -719,6 +719,10 @@ if (isset($_ENV['DRUPAL_SETTINGS'])) {
 /** Todo: create better patterns on production sites */
 if ($drupal_settings !== 'production') {
   $settings['trusted_host_patterns'] = array('[\s\S]*');
+
+  // Necessary as per #3188183.
+  $settings['swiftmailer.transport']['smtp_host'] = 'mailcatcher';
+  $settings['swiftmailer.transport']['smtp_port'] = '1025';
 }
 
 /**
@@ -742,6 +746,6 @@ if ($drupal_settings === 'development' && file_exists(__DIR__ . '/settings.local
 
 /** Everything after here is added by the installation process.
  *
- * TODO: improve the installtion by putting the settings.local part below these
+ * TODO: improve the installation by putting the settings.local part below these
  * settings.
  */

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Ensure we exit with an error on drush errors.
-set -e
-
 LOCAL=$1
 NFS=$2
 DEV=$3
@@ -112,6 +110,14 @@ if [ ! -d /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer
 fi
 chmod 777 -R /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool;
 chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool
+
+# Make sure we add swiftmailer default settings if it exists as container.
+if drush ev "echo getenv('DRUPAL_SETTINGS');" | grep -q 'development'; then
+  drush cset swiftmailer.transport transport 'smtp' -y
+  drush cset swiftmailer.transport smtp_host 'mailcatcher' -y
+  drush cset swiftmailer.transport smtp_port 1025 -y
+  echo "updated mailcachter settings"
+fi
 
 fn_sleep
 echo "settings.php and files directory permissions"

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -26,8 +26,12 @@ case ${i} in
       NFS=nfs
       shift # past argument with no value
       ;;
+    -ls|--localsettings)
+      SETTINGS='local'
+      shift # past argument with no value
+      ;;
     -wo|--with-optional)
-      OPTIONAL=optional
+      OPTIONAL='optional'
       shift # past argument with no value
       ;;
     -s|--skip-content)
@@ -111,12 +115,21 @@ fi
 chmod 777 -R /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool;
 chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool
 
-# Make sure we add swiftmailer default settings if it exists as container.
+# Make sure we add swiftmailer default settings if the environment is development
 if drush ev "echo getenv('DRUPAL_SETTINGS');" | grep -q 'development'; then
   drush cset swiftmailer.transport transport 'smtp' -y
   drush cset swiftmailer.transport smtp_host 'mailcatcher' -y
   drush cset swiftmailer.transport smtp_port 1025 -y
-  echo "updated mailcachter settings"
+  echo "updated swiftmailer settings"
+fi
+
+# Make sure we add swiftmailer default settings if the environment is set to local.
+if [[ ${SETTINGS} == "local" ]]
+then
+  drush cset swiftmailer.transport transport 'smtp' -y
+  drush cset swiftmailer.transport smtp_host 'mailcatcher' -y
+  drush cset swiftmailer.transport smtp_port 1025 -y
+  echo "updated swiftmailer settings"
 fi
 
 fn_sleep

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Ensure we exit with an error on drush errors.
+set -e
+
 LOCAL=$1
 NFS=$2
 DEV=$3


### PR DESCRIPTION
See: https://github.com/goalgorilla/open_social/pull/2131

The update of Swiftmailer removed PHP as option due to possible security impediments.
https://www.drupal.org/project/swiftmailer/issues/3143292

We decided to use mailcatchers built-in SMTP.

1) That's why we can't do it in Open Social repo's code.
2) Also since not everybody uses settings.local.php we can't add it there
3) Therefor I'll update developer documentation, and as a helper for re-installing for our development environments where we use mailcatcher as a docker container I've added the below.

## HTT

- [ ] Run `drupal site:mode dev` and run reinstall, see that the settings apply for mailcatcher when site is in development mode
- [ ] Run `docker exec -i social_ci_web bash /var/www/scripts/social/install/install_script.sh --with-optional --localsettings` to see it applies