### PR TITLE
We are removing social_devel

### DIFF
--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -177,5 +177,5 @@ drush php-eval 'node_access_rebuild()';
 if [[ ${DEV} == "dev" ]]
 then
   echo "enabling devel modules"
-  drush en social_devel -y
+  drush en -y config_update config_update_ui devel kint devel_generate dblog views_ui field_ui contextual
 fi

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -177,5 +177,5 @@ drush php-eval 'node_access_rebuild()';
 if [[ ${DEV} == "dev" ]]
 then
   echo "enabling devel modules"
-  drush en -y config_update config_update_ui devel kint devel_generate dblog views_ui field_ui contextual
+  drush en -y config_update config_update_ui devel devel_generate dblog views_ui field_ui contextual
 fi


### PR DESCRIPTION
We are removing social_devel as per https://github.com/goalgorilla/open_social/pull/2397 and are moving devel as dependency to require-dev of composer.
This also means we can't use this as enabler, however we can enable all submodules directly.