### PR TITLE
Add default configuration for the symfony mailer module.

### DIFF
--- a/ci/drush-make-install.sh
+++ b/ci/drush-make-install.sh
@@ -6,7 +6,7 @@ ls -lah
 cd make_build;
 ls -lah
 composer config repositories.drupal composer https://packages.drupal.org/8
-composer require "drupal/address ~1.0" "drupal/social_auth ^1.0" "facebook/graph-sdk ^5.4" "google/apiclient ^2.1" "php-http/curl-client ^1.6" "guzzlehttp/psr7 ^1.3" "php-http/message ^1.4" "happyr/linkedin-api-client ^1.0" "abraham/twitteroauth ^0.7.2" "swiftmailer/swiftmailer 5.4.8"
+composer require "drupal/address ~1.0" "drupal/social_auth ^1.0" "facebook/graph-sdk ^5.4" "google/apiclient ^2.1" "php-http/curl-client ^1.6" "guzzlehttp/psr7 ^1.3" "php-http/message ^1.4" "happyr/linkedin-api-client ^1.0" "abraham/twitteroauth ^0.7.2"
 
 # Now cleanup the old stuff.
 cd ../

--- a/install/default.settings.php
+++ b/install/default.settings.php
@@ -719,10 +719,6 @@ if (isset($_ENV['DRUPAL_SETTINGS'])) {
 /** Todo: create better patterns on production sites */
 if ($drupal_settings !== 'production') {
   $settings['trusted_host_patterns'] = array('[\s\S]*');
-
-  // Necessary as per #3188183.
-  $settings['swiftmailer.transport']['smtp_host'] = 'mailcatcher';
-  $settings['swiftmailer.transport']['smtp_port'] = '1025';
 }
 
 /**

--- a/install/default.settings.php
+++ b/install/default.settings.php
@@ -738,6 +738,8 @@ $settings['file_private_path'] =  '/var/www/files_private';
  */
 if ($drupal_settings === 'development' && file_exists(__DIR__ . '/settings.local.php')) {
   include __DIR__ . '/settings.local.php';
+  // See: https://www.drupal.org/docs/contributed-modules/symfony-mailer-0/getting-started#s-mailhog
+  $config['symfony_mailer.mailer_transport.sendmail']['configuration']['query']['command'] = ini_get('sendmail_path') . ' -t';
 }
 
 /** Everything after here is added by the installation process.

--- a/install/default.settings.php
+++ b/install/default.settings.php
@@ -738,8 +738,6 @@ $settings['file_private_path'] =  '/var/www/files_private';
  */
 if ($drupal_settings === 'development' && file_exists(__DIR__ . '/settings.local.php')) {
   include __DIR__ . '/settings.local.php';
-  // See: https://www.drupal.org/docs/contributed-modules/symfony-mailer-0/getting-started#s-mailhog
-  $config['symfony_mailer.mailer_transport.sendmail']['configuration']['query']['command'] = ini_get('sendmail_path') . ' -t';
 }
 
 /** Everything after here is added by the installation process.

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -113,17 +113,18 @@ fi
 chmod 777 -R /var/www/files_private;
 chmod 777 -R sites/default/files
 
-# Create symfony-mailer-spool directory for behat tests
-if [ ! -d /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool ]; then
-  mkdir /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
-fi
-chmod 777 -R /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
-chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool
-
 # Make sure we add mailer default settings if the environment is development
 if [[ $(drush ev "echo getenv('DRUPAL_SETTINGS');" | grep "development") ]] || [[ ${SETTINGS} = "local" ]]; then
   # Enable symfony mailer only for the OS 12+
   if [ -n ${OS_VERSION} ] && [ ${OS_VERSION} -ge "12000000000" ]; then
+    # Create spool directory for behat tests
+    if [ ! -d /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool ]; then
+      mkdir /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
+    fi
+    chmod 777 -R /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
+    chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
+
+    # Configure mailcatcher transport
     drush ev "\Drupal::service('config.factory')->getEditable('symfony_mailer.mailer_transport.mailcatcher')->set('id', 'mailcatcher')->save();"
     drush cset symfony_mailer.mailer_transport.mailcatcher label Mailcatcher -y
     drush cset symfony_mailer.mailer_transport.mailcatcher plugin smtp -y
@@ -132,6 +133,14 @@ if [[ $(drush ev "echo getenv('DRUPAL_SETTINGS');" | grep "development") ]] || [
     drush cset symfony_mailer.settings default_transport mailcatcher -y
     echo "updated symfony mailer settings"
   else
+    # Create spool directory for behat tests
+    if [ ! -d /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool ]; then
+      mkdir /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool;
+    fi
+    chmod 777 -R /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool;
+    chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool;
+
+    # Configure mailcatcher transport
     drush cset swiftmailer.transport transport 'smtp' -y
     drush cset swiftmailer.transport smtp_host 'mailcatcher' -y
     drush cset swiftmailer.transport smtp_port 1025 -y

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -115,8 +115,8 @@ chmod 777 -R sites/default/files
 
 # Make sure we add mailer default settings if the environment is development
 if [[ $(drush ev "echo getenv('DRUPAL_SETTINGS');" | grep "development") ]] || [[ ${SETTINGS} = "local" ]]; then
-  # Enable symfony mailer only for the OS 12+
-  if [ -n ${OS_VERSION} ] && [ ${OS_VERSION} -ge "12000000000" ]; then
+  # Enable symfony mailer only for the OS 11.5+
+  if [ -n ${OS_VERSION} ] && [ ${OS_VERSION} -ge "11500000000" ]; then
     # Create spool directory for behat tests
     if [ ! -d /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool ]; then
       mkdir /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -125,12 +125,11 @@ if [[ $(drush ev "echo getenv('DRUPAL_SETTINGS');" | grep "development") ]] || [
     chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
 
     # Configure mailcatcher transport
-    drush ev "\Drupal::service('config.factory')->getEditable('symfony_mailer.mailer_transport.mailcatcher')->set('id', 'mailcatcher')->save();"
-    drush cset symfony_mailer.mailer_transport.mailcatcher label Mailcatcher -y
-    drush cset symfony_mailer.mailer_transport.mailcatcher plugin smtp -y
-    drush cset symfony_mailer.mailer_transport.mailcatcher configuration.host mailcatcher -y
-    drush cset symfony_mailer.mailer_transport.mailcatcher configuration.port 1025 -y
-    drush cset symfony_mailer.settings default_transport mailcatcher -y
+    drush cset symfony_mailer.mailer_transport.sendmail plugin 'smtp' -y
+    drush cset symfony_mailer.mailer_transport.sendmail configuration.user '' -y
+    drush cset symfony_mailer.mailer_transport.sendmail configuration.passs '' -y
+    drush cset symfony_mailer.mailer_transport.sendmail configuration.host 'mailcatcher' -y
+    drush cset symfony_mailer.mailer_transport.sendmail configuration.port '1025' -y
     echo "updated symfony mailer settings"
   else
     # Create spool directory for behat tests

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -7,7 +7,7 @@ NFS=$2
 DEV=$3
 OPTIONAL=$4
 SETTINGS=$5
-OS_VERSION=$(composer show goalgorilla/open_social | sed -n '/versions/s/^[^0-9]\+\([^,]\+\).*$/\1/p') | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+OS_VERSION=$(composer show goalgorilla/open_social | sed -n '/versions/s/^[^0-9]\+\([^,]\+\).*$/\1/p' | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }')
 
 fn_sleep() {
   if [[ ${LOCAL} != "nopause" ]]

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -127,7 +127,7 @@ if [[ $(drush ev "echo getenv('DRUPAL_SETTINGS');" | grep "development") ]] || [
     # Configure mailcatcher transport
     drush cset symfony_mailer.mailer_transport.sendmail plugin 'smtp' -y
     drush cset symfony_mailer.mailer_transport.sendmail configuration.user '' -y
-    drush cset symfony_mailer.mailer_transport.sendmail configuration.passs '' -y
+    drush cset symfony_mailer.mailer_transport.sendmail configuration.pass '' -y
     drush cset symfony_mailer.mailer_transport.sendmail configuration.host 'mailcatcher' -y
     drush cset symfony_mailer.mailer_transport.sendmail configuration.port '1025' -y
     echo "updated symfony mailer settings"

--- a/install/install_script.sh
+++ b/install/install_script.sh
@@ -112,28 +112,34 @@ fi
 chmod 777 -R /var/www/files_private;
 chmod 777 -R sites/default/files
 
-# Create swiftmailer-spool directory for behat tests
-if [ ! -d /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool ]; then
-  mkdir /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool;
+# Create symfony-mailer-spool directory for behat tests
+if [ ! -d /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool ]; then
+  mkdir /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
 fi
-chmod 777 -R /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool;
-chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/swiftmailer-spool
+chmod 777 -R /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool;
+chown -R www-data:www-data /var/www/html/profiles/contrib/social/tests/behat/features/symfony-mailer-spool
 
-# Make sure we add swiftmailer default settings if the environment is development
+# Make sure we add symfony mailer default settings if the environment is development
 if drush ev "echo getenv('DRUPAL_SETTINGS');" | grep -q 'development'; then
-  drush cset swiftmailer.transport transport 'smtp' -y
-  drush cset swiftmailer.transport smtp_host 'mailcatcher' -y
-  drush cset swiftmailer.transport smtp_port 1025 -y
-  echo "updated swiftmailer settings"
+  drush ev "\Drupal::service('config.factory')->getEditable('symfony_mailer.mailer_transport.mailcatcher')->set('id', 'mailcatcher')->save();"
+  drush cset symfony_mailer.mailer_transport.mailcatcher label Mailcatcher -y
+  drush cset symfony_mailer.mailer_transport.mailcatcher plugin smtp -y
+  drush cset symfony_mailer.mailer_transport.mailcatcher configuration.host mailcatcher -y
+  drush cset symfony_mailer.mailer_transport.mailcatcher configuration.port 1025 -y
+  drush cset symfony_mailer.settings default_transport mailcatcher -y
+  echo "updated symfony mailer settings"
 fi
 
-# Make sure we add swiftmailer default settings if the environment is set to local.
+# Make sure we add symfony mailer default settings if the environment is set to local.
 if [[ ${SETTINGS} == "local" ]]
 then
-  drush cset swiftmailer.transport transport 'smtp' -y
-  drush cset swiftmailer.transport smtp_host 'mailcatcher' -y
-  drush cset swiftmailer.transport smtp_port 1025 -y
-  echo "updated swiftmailer settings"
+  drush ev "\Drupal::service('config.factory')->getEditable('symfony_mailer.mailer_transport.mailcatcher')->set('id', 'mailcatcher')->save();"
+  drush cset symfony_mailer.mailer_transport.mailcatcher label Mailcatcher -y
+  drush cset symfony_mailer.mailer_transport.mailcatcher plugin smtp -y
+  drush cset symfony_mailer.mailer_transport.mailcatcher configuration.host mailcatcher -y
+  drush cset symfony_mailer.mailer_transport.mailcatcher configuration.port 1025 -y
+  drush cset symfony_mailer.settings default_transport mailcatcher -y
+  echo "updated symfony mailer settings"
 fi
 
 fn_sleep


### PR DESCRIPTION
In this PR I removed configuration for the swiftmailer and added configuration for the symfony mailer module.
`drush ev` is used because `drush cset` cannot create new configuration.