### PR TITLE
Add script to easily execute tugboat commands

### DIFF
--- a/social-tugboat.sh
+++ b/social-tugboat.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Prompt for GitHub PR ID
+read -p "Enter the GitHub PR ID number (e.g., 3959): " GH_PR
+
+# Hardcoded repo ID
+REPO_ID="630373f56d9ec36a0f50b5d5"
+
+echo "🔍 Searching for preview matching: $GH_PR"
+
+# Get all previews
+PREVIEWS=$(tugboat ls previews repo="$REPO_ID")
+
+# Find line number of match (URL line)
+MATCH_LINE_NUM=$(echo "$PREVIEWS" | grep -in "$GH_PR" | cut -d: -f1)
+
+if [ -z "$MATCH_LINE_NUM" ]; then
+  echo "❌ No Tugboat preview found matching: $GH_PR"
+  exit 1
+fi
+
+# Get the line above the matched line
+ID_LINE=$(echo "$PREVIEWS" | sed -n "$((MATCH_LINE_NUM - 1))p")
+
+# Extract the first column (should be preview ID)
+POTENTIAL_ID=$(echo "$ID_LINE" | awk '{print $1}')
+
+# Validate preview ID format (24 hex chars)
+if [[ "$POTENTIAL_ID" =~ ^[a-f0-9]{24}$ ]]; then
+  PREVIEW_ID="$POTENTIAL_ID"
+  echo "✅ Found Preview ID: $PREVIEW_ID"
+else
+  echo "❌ Invalid preview ID extracted: $POTENTIAL_ID"
+  exit 1
+fi
+
+# Get the webserver service ID
+SERVICE_ID=$(tugboat ls services preview="$PREVIEW_ID" --json \
+  | jq -r '.[] | select(.name=="webserver") | .id')
+
+if [ -z "$SERVICE_ID" ]; then
+  echo "❌ No webserver service found for preview: $PREVIEW_ID"
+  exit 1
+fi
+
+echo "✅ Webserver Service ID: $SERVICE_ID"
+
+# Show options
+while true; do
+  echo
+  echo "What would you like to do next?"
+  echo "1) Enable Drupal module(s)"
+  echo "2) Run a custom Drush command"
+  echo "3) Download database (drush sql-dump)"
+  echo "4) Exit"
+  read -p "Choose an option (1/2/3/4): " NEXT_ACTION
+
+  if [ "$NEXT_ACTION" == "2" ]; then
+    read -p "Enter the Drush command to run (without 'drush'): " DRUSH_COMMAND
+    echo "🚀 Running: drush $DRUSH_COMMAND"
+    tugboat shell "$SERVICE_ID" command="/var/www/vendor/drush/drush/drush $DRUSH_COMMAND"
+
+  elif [ "$NEXT_ACTION" == "1" ]; then
+    while true; do
+      read -p "Enter the module name to enable: " MODULE_NAME
+      echo "🚀 Enabling module: $MODULE_NAME"
+      tugboat shell "$SERVICE_ID" command="/var/www/vendor/drush/drush/drush en $MODULE_NAME -y"
+
+      echo
+      read -p "Do you want to enable another module? (y/n): " ENABLE_ANOTHER
+      if [[ "$ENABLE_ANOTHER" != "y" && "$ENABLE_ANOTHER" != "Y" ]]; then
+        echo "👋 Done enabling modules."
+        break
+      fi
+    done
+
+  elif [ "$NEXT_ACTION" == "3" ]; then
+    echo "💾 Downloading database dump to local file: database.sql"
+    tugboat shell "$SERVICE_ID" command="/var/www/vendor/drush/drush/drush sql-dump" > database.sql
+    echo "✅ Dump saved as database.sql"
+
+  elif [ "$NEXT_ACTION" == "4" ]; then
+    echo "👋 Exiting."
+    break
+
+  else
+    echo "❌ Invalid option selected."
+  fi
+done


### PR DESCRIPTION
Added a small bash script to easily execute tugboat stuff without the need to go into the web terminal interface and remember all those commands. This should also prevent people from using the Drupal Module Interface to enable modules which can time-out.

All you need to do is install the tugboat cli with
```
brew tap tugboatqa/tugboat
brew install tugboat-cli
```
and setup an access token on
[https://dashboard.tugboatqa.com/access-tokens](https://dashboard.tugboatqa.com/access-tokens
)
When you then run the script for the first time it will ask you for this access-token.
`bash social-tugboat.sh `
After that you are able to enable modules, runs custom drush commands or download the database locally.

<img width="283" height="106" alt="Screenshot 2025-07-31 at 12 58 45" src="https://github.com/user-attachments/assets/714f69ae-c96d-4a21-86b8-4b2b90af884b" />
